### PR TITLE
Fix boot loop and NAND image for BPI-R4 POE

### DIFF
--- a/builder-wifimgr-universal.sh
+++ b/builder-wifimgr-universal.sh
@@ -77,6 +77,12 @@ chmod +x files/etc/init.d/mtk-led-fix
 \cp ../my_files/etc-files/uci-defaults/95-mtk-led-fix-enable files/etc/uci-defaults/
 chmod +x files/etc/uci-defaults/95-mtk-led-fix-enable
 
+# WAN on the 2.5GbE/PoE jack: stock defaults bridge that port ("lan4") into
+# br-lan, so an uplink plugged there links up but never gets a WAN lease;
+# move it to br-wan (bpi-r4-2g5/poe boards only, no-op elsewhere)
+\cp ../my_files/etc-files/uci-defaults/98-poe-wan-port files/etc/uci-defaults/
+chmod +x files/etc/uci-defaults/98-poe-wan-port
+
 # SD auto-expand: grow production + fitrw f2fs to fill the SD card on first boot (SD-only, guarded)
 mkdir -p files/lib/preinit
 \cp ../my_files/etc-files/lib/preinit/19-expand-fit-rootfs files/lib/preinit/

--- a/builder-wired-universal.sh
+++ b/builder-wired-universal.sh
@@ -66,6 +66,12 @@ chmod +x files/etc/init.d/mtk-led-fix
 \cp ../my_files/etc-files/uci-defaults/95-mtk-led-fix-enable files/etc/uci-defaults/
 chmod +x files/etc/uci-defaults/95-mtk-led-fix-enable
 
+# WAN on the 2.5GbE/PoE jack: stock defaults bridge that port ("lan4") into
+# br-lan, so an uplink plugged there links up but never gets a WAN lease;
+# move it to br-wan (bpi-r4-2g5/poe boards only, no-op elsewhere)
+\cp ../my_files/etc-files/uci-defaults/98-poe-wan-port files/etc/uci-defaults/
+chmod +x files/etc/uci-defaults/98-poe-wan-port
+
 # SD auto-expand: grow production + fitrw f2fs to fill the SD card on first boot (SD-only, guarded)
 mkdir -p files/lib/preinit
 \cp ../my_files/etc-files/lib/preinit/19-expand-fit-rootfs files/lib/preinit/

--- a/my_files/471-w-bpi-r4-led-uboot.patch
+++ b/my_files/471-w-bpi-r4-led-uboot.patch
@@ -88,7 +88,7 @@
 @@ -2,4 +2,4 @@
  bootconf=config-mt7988a-bananapi-bpi-r4-poe
 -bootconf_extra=mt7988a-bananapi-bpi-r4-emmc
-+bootconf_extra=mt7988a-bananapi-bpi-r4-emmc#mt7988a-bananapi-bpi-r4-leds
++bootconf_extra=mt7988a-bananapi-bpi-r4-spim-nand#mt7988a-bananapi-bpi-r4-emmc#mt7988a-bananapi-bpi-r4-leds
 -bootcmd=if pstore check ; then run boot_recovery ; else run boot_ubi ; fi
 +bootcmd=mdio write mt7988 0 1f.24 c007 ; mdio write mt7988 1 1f.24 c007 ; mdio write mt7988 2 1f.24 8007 ; mdio write mt7988 3 1f.24 8007 ; if pstore check ; then run boot_recovery ; else run boot_ubi ; fi
  bootdelay=0

--- a/my_files/etc-files/uci-defaults/98-poe-wan-port
+++ b/my_files/etc-files/uci-defaults/98-poe-wan-port
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# BPI-R4 2.5GbE variants (bpi-r4-2g5 / bpi-r4-poe): the 2.5GbE RJ45 jack -
+# the PoE-in uplink port on the PoE board - enumerates as "lan4", and the
+# stock OpenWrt defaults bridge it into br-lan. An uplink cable plugged
+# there shows link but gets bridged into the LAN: the router never asks
+# for a WAN lease and has no internet (seen live 2026-07-21). Move the
+# port to br-wan so any copper uplink jack (wan, sfp-wan or 2.5G/PoE)
+# works as WAN. Idempotent: also migrates configs preserved by sysupgrade.
+
+. /lib/functions.sh
+
+case "$(board_name)" in
+bananapi,bpi-r4-2g5|\
+bananapi,bpi-r4-poe) ;;
+*) exit 0 ;;
+esac
+
+lan_sec="" wan_sec=""
+find_bridge() {
+	local name
+	config_get name "$1" name
+	case "$name" in
+	br-lan) lan_sec="$1" ;;
+	br-wan) wan_sec="$1" ;;
+	esac
+}
+config_load network
+config_foreach find_bridge device
+[ -n "$lan_sec" ] && [ -n "$wan_sec" ] || exit 0
+
+uci -q del_list "network.$lan_sec.ports=lan4"
+uci -q get "network.$wan_sec.ports" | grep -qw lan4 || \
+	uci add_list "network.$wan_sec.ports=lan4"
+uci commit network
+exit 0

--- a/my_files/w-filogic-bpi-r4-universal.mk
+++ b/my_files/w-filogic-bpi-r4-universal.mk
@@ -149,6 +149,12 @@ endif
 
 endef
 
+# $(1): U-Boot FIP base name (bananapi_bpi-r4 or bananapi_bpi-r4-poe).
+# Passed as a call argument on purpose: a shared make variable here — even a
+# DEVICE_VARS-registered one — is captured from the previously parsed device
+# during template expansion, which shipped poe-8gb images with the non-PoE
+# U-Boot env (bootconf mismatch -> TFTP boot loop). Call args substitute
+# textually and cannot leak between devices.
 define Device/bananapi_bpi-r4-common-8gb
   DEVICE_VENDOR := Bananapi
   DEVICE_DTS_DIR := $(DTS_DIR)/
@@ -166,7 +172,6 @@ mt7988a-bananapi-bpi-r4-nvme
   DEVICE_COMPAT_VERSION := 1.1
   DEVICE_COMPAT_MESSAGE := The non-switch ports were renamed to match the board/case labels
   KERNEL_LOADADDR := 0x46000000
-  BPI_R4_FIP_NAME := bananapi_bpi-r4
 
   ARTIFACTS := \
       emmc-img.bin \
@@ -175,7 +180,7 @@ mt7988a-bananapi-bpi-r4-nvme
       snand-img.bin
   ARTIFACT/emmc-img.bin := mt798x-gpt emmc | \
   pad-to 17k | mt7988-bl2 emmc-comb-4bg | \
-  pad-to 6656k | mt7988-bl31-uboot $$(BPI_R4_FIP_NAME)-emmc | \
+  pad-to 6656k | mt7988-bl31-uboot $(1)-emmc | \
   pad-to 64M | append-image squashfs-sysupgrade.itb
   ARTIFACT/nvme-img.bin := mt798x-gpt-nvme | \
   pad-to 512M | append-image squashfs-sysupgrade.itb
@@ -184,11 +189,11 @@ mt7988a-bananapi-bpi-r4-nvme
   ubinize-image fit squashfs-sysupgrade.itb
   ARTIFACT/sdcard.img.gz := mt798x-gpt sdmmc |\
   pad-to 17k | mt7988-bl2 sdmmc-comb-4bg |\
-  pad-to 6656k | mt7988-bl31-uboot $$(BPI_R4_FIP_NAME)-sdmmc |\
+  pad-to 6656k | mt7988-bl31-uboot $(1)-sdmmc |\
   pad-to 44M | mt7988-bl2 spim-nand-ubi-comb-4bg |\
-  pad-to 45M | mt7988-bl31-uboot $$(BPI_R4_FIP_NAME)-snand |\
+  pad-to 45M | mt7988-bl31-uboot $(1)-snand |\
   pad-to 51M | mt7988-bl2 emmc-comb-4bg |\
-  pad-to 52M | mt7988-bl31-uboot $$(BPI_R4_FIP_NAME)-emmc |\
+  pad-to 52M | mt7988-bl31-uboot $(1)-emmc |\
   pad-to 56M | mt798x-gpt emmc |\
 $(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
   pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
@@ -236,7 +241,7 @@ define Device/bananapi_bpi-r4-8gb
   DEVICE_MODEL := BPi-R4 8GB
   DEVICE_DTS := mt7988a-bananapi-bpi-r4
   DEVICE_DTS_CONFIG := config-mt7988a-bananapi-bpi-r4
-  $(call Device/bananapi_bpi-r4-common-8gb)
+  $(call Device/bananapi_bpi-r4-common-8gb,bananapi_bpi-r4)
   ARTIFACTS := emmc-img.bin nvme-img.bin sdcard.img.gz
   DEVICE_PACKAGES += docker dockerd docker-compose containerd runc
   SUPPORTED_DEVICES += bananapi,bpi-r4
@@ -247,12 +252,11 @@ define Device/bananapi_bpi-r4-poe-8gb
   DEVICE_MODEL := BPi-R4 2.5GE 8GB
   DEVICE_DTS := mt7988a-bananapi-bpi-r4-2g5
   DEVICE_DTS_CONFIG := config-mt7988a-bananapi-bpi-r4-poe
-  $(call Device/bananapi_bpi-r4-common-8gb)
+  $(call Device/bananapi_bpi-r4-common-8gb,bananapi_bpi-r4-poe)
   DEVICE_PACKAGES += mt798x-2p5g-phy-firmware-internal kmod-mt798x-2p5g-phy
   DEVICE_PACKAGES += docker dockerd docker-compose containerd runc
   ARTIFACTS := emmc-img.bin nvme-img.bin sdcard.img.gz
   SUPPORTED_DEVICES += bananapi,bpi-r4-2g5
-  BPI_R4_FIP_NAME := bananapi_bpi-r4-poe
   UBINIZE_PARTS := fip=:$(STAGING_DIR_IMAGE)/mt7988_bananapi_bpi-r4-poe-snand-u-boot.fip
 endef
 TARGET_DEVICES += bananapi_bpi-r4-poe-8gb
@@ -273,7 +277,7 @@ define Device/bananapi_bpi-r4-nand-8gb
   DEVICE_MODEL := BPi-R4 NAND installer 8GB
   DEVICE_DTS := mt7988a-bananapi-bpi-r4
   DEVICE_DTS_CONFIG := config-mt7988a-bananapi-bpi-r4
-  $(call Device/bananapi_bpi-r4-common-8gb)
+  $(call Device/bananapi_bpi-r4-common-8gb,bananapi_bpi-r4)
   ARTIFACTS := snand-img.bin
 endef
 TARGET_DEVICES += bananapi_bpi-r4-nand-8gb

--- a/my_files/w-filogic-bpi-r4-universal.mk
+++ b/my_files/w-filogic-bpi-r4-universal.mk
@@ -281,3 +281,20 @@ define Device/bananapi_bpi-r4-nand-8gb
   ARTIFACTS := snand-img.bin
 endef
 TARGET_DEVICES += bananapi_bpi-r4-nand-8gb
+
+# Full PoE system running from NAND (not just an installer). The DTS maps only
+# 128 MiB of the SPI-NAND (BL2 2 MiB + ubi 126 MiB) regardless of the 256 MiB
+# chip, leaving 122 MiB of UBI. A docker-bearing FIT is 106.5 MiB of that and
+# strands rootfs_data at 4 MiB; without docker the FIT is 49 MiB and the
+# overlay comes out at 57 MiB (both measured on a Winbond 256 MiB part).
+define Device/bananapi_bpi-r4-poe-nand-8gb
+  DEVICE_MODEL := BPi-R4 2.5GE 8GB NAND
+  DEVICE_DTS := mt7988a-bananapi-bpi-r4-2g5
+  DEVICE_DTS_CONFIG := config-mt7988a-bananapi-bpi-r4-poe
+  $(call Device/bananapi_bpi-r4-common-8gb,bananapi_bpi-r4-poe)
+  DEVICE_PACKAGES += mt798x-2p5g-phy-firmware-internal kmod-mt798x-2p5g-phy
+  ARTIFACTS := snand-img.bin
+  SUPPORTED_DEVICES += bananapi,bpi-r4-2g5
+  UBINIZE_PARTS := fip=:$(STAGING_DIR_IMAGE)/mt7988_bananapi_bpi-r4-poe-snand-u-boot.fip
+endef
+TARGET_DEVICES += bananapi_bpi-r4-poe-nand-8gb


### PR DESCRIPTION
The image for POE version of BPI-R4 was broken - the router didn't load at all.
Besides that there was no NAND image for POE version of BPI-R4.

I have fixed both issues. Now everything works fine.